### PR TITLE
Change ssh url to https url for gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = git@github.com:tonlabs/common
+	url = https://github.com/tonlabs/common.git


### PR DESCRIPTION
https url in gitmodules more useful than ssh url. 
Now, I build source code on new server and I don't use ssh key for github account.
