### PR TITLE
add commits hash and build info to the binary file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
-build = 'common/build/build.rs'
+build = 'src/build.rs'
 edition = '2021'
 name = 'ton_node'
 version = '0.51.14'
 
 [workspace]
 members = [ 'storage' ]
+
+[build-dependencies]
+toml = "0.5"
 
 [dependencies]
 async-recursion = '0.3.2'

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,231 @@
+/*
+* Copyright 2018-2022 TON DEV SOLUTIONS LTD.
+*
+* Licensed under the SOFTWARE EVALUATION License (the "License"); you may not use
+* this file except in compliance with the License.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific TON DEV software governing permissions and
+* limitations under the License.
+*/
+
+use std::env;
+use std::process::Command;
+use std::fs;
+use std::io::{prelude::*};
+use toml::{Value as Toml};
+
+// =========================================================
+
+fn main() -> Result<(), String> {
+    //let car_man_dir = std::option_env!("CARGO_MANIFEST_DIR").unwrap_or("Not set").to_string();
+    
+    let build_mode: &str;
+    if Ok("release".to_owned()) == std::env::var("PROFILE") {
+        build_mode = "RELEASE";
+    } else 
+    {
+        build_mode = "DEBUG";
+    } 
+
+    execute_command(Command::new("cargo").arg("update"))?;
+
+    let cargo_toml = get_toml("Cargo.toml");
+    let top_pkg_name = parse_package_name(&cargo_toml);
+    let cargo_lock = get_toml("Cargo.lock");
+    let cargo_evx_deps_list = parse_deps(&cargo_lock, top_pkg_name)?;
+
+
+    let mut gc_abi: String = String::new();
+    let mut gc_adnl: String = String::new();
+    let mut gc_block_json: String = String::new();
+    let mut gc_block: String = String::new();
+    let mut gc_crypto: String = String::new();
+    let mut gc_dht: String = String::new();
+    let mut gc_executor: String = String::new();
+    let mut gc_overlay: String = String::new();
+    let mut gc_rldp: String = String::new();
+    let mut gc_tl: String = String::new();
+    let mut gc_types: String = String::new();
+    let mut gc_vm: String = String::new();
+    let mut gc_lockfree: String = String::new();
+   
+    for curr_dep in cargo_evx_deps_list {
+        let dep_hash: String = curr_dep.clone().split("#").last().unwrap().to_string();
+        if curr_dep.contains("labs-abi")        {gc_abi          =  dep_hash} else 
+        if curr_dep.contains("labs-adnl")       {gc_adnl         =  dep_hash;} else 
+        if curr_dep.contains("labs-block-json") {gc_block_json   =  dep_hash;} else 
+        if curr_dep.contains("labs-block")      {gc_block        =  dep_hash;} else 
+        if curr_dep.contains("labs-crypto")     {gc_crypto       =  dep_hash;} else 
+        if curr_dep.contains("labs-dht")        {gc_dht          =  dep_hash;} else 
+        if curr_dep.contains("labs-executor")   {gc_executor     =  dep_hash;} else 
+        if curr_dep.contains("labs-overlay")    {gc_overlay      =  dep_hash;} else 
+        if curr_dep.contains("labs-rldp")       {gc_rldp         =  dep_hash;} else 
+        if curr_dep.contains("labs-tl")         {gc_tl           =  dep_hash;} else 
+        if curr_dep.contains("labs-types")      {gc_types        =  dep_hash;} else 
+        if curr_dep.contains("labs-vm")         {gc_vm           =  dep_hash;} else 
+        if curr_dep.contains("lockfree")        {gc_lockfree     =  dep_hash;} 
+    }
+
+    // =========================================================
+
+    let git_branch_remote = get_value("git", &["name-rev", "--name-only", "HEAD"]);
+    let gb: Vec<&str> = git_branch_remote.split('/').collect::<Vec<&str>>();
+    let git_branch = gb.last().unwrap();
+
+    let git_commit =    get_value("git",    &["rev-parse", "HEAD"]);
+    let commit_date =   get_value("git",    &["log", "-1", "--date=iso", "--pretty=format:%cd"]);
+    let build_time =    get_value("date",   &["+%Y-%m-%d %T %z"]);
+    let rust_version =  get_value("rustc",  &["--version"]);
+
+    // =========================================================
+
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={}",   rust_version);
+    println!("cargo:rustc-env=BUILD_TIME={}",           build_time);
+    println!("cargo:rustc-env=BUILD_MODE={}",           build_mode);
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}",     git_commit);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}",     git_branch);
+    println!("cargo:rustc-env=BUILD_GIT_DATE={}",       commit_date);
+
+    println!("cargo:rustc-env=GC_ABI={}",           gc_abi);
+    println!("cargo:rustc-env=GC_ADNL={}",          gc_adnl);
+    println!("cargo:rustc-env=GC_BLOCK_JSON={}",    gc_block_json);
+    println!("cargo:rustc-env=GC_BLOCK={}",         gc_block);
+    println!("cargo:rustc-env=GC_CRYPTO={}",        gc_crypto);
+    println!("cargo:rustc-env=GC_DHT={}",           gc_dht);
+    println!("cargo:rustc-env=GC_EXECUTOR={}",      gc_executor);
+    println!("cargo:rustc-env=GC_OVERLAY={}",       gc_overlay);
+    println!("cargo:rustc-env=GC_RLDP={}",          gc_rldp);
+    println!("cargo:rustc-env=GC_TL={}",            gc_tl);
+    println!("cargo:rustc-env=GC_TYPES={}",         gc_types);
+    println!("cargo:rustc-env=GC_VM={}",            gc_vm);
+    println!("cargo:rustc-env=GC_LOCKFREE={}",      gc_lockfree);
+
+    Ok(())
+}
+
+// #########################################################################################################
+fn get_value(cmd: &str, args: &[&str]) -> String {
+    if let Ok(result) = Command::new(cmd).args(args).output() {
+        if let Ok(result) = String::from_utf8(result.stdout) {
+            return result
+        }
+    }
+    "Unknown".to_string()
+}
+fn execute_command(command: &mut Command) -> Result<(), String> {
+    let mut child = command.envs(env::vars()).spawn()
+        .map_err(|_| "failed to execute process".to_string())?;
+
+    let exit_status = child.wait().expect("failed to run command");
+
+    if !exit_status.success() {
+        match exit_status.code() {
+            Some(code) => Err(format!("Exited with status code: {}", code)),
+            None => Err(format!("Process terminated by signal")),
+        }
+    } else {
+        Ok(())
+    }
+}
+
+fn get_toml(file_path: &str) -> Toml {
+    let mut toml_file = fs::File::open(file_path).unwrap();
+    let mut toml_string = String::new();
+    toml_file.read_to_string(&mut toml_string).unwrap();
+    toml_string.parse().expect("failed to parse toml")
+}
+
+fn parse_package_name(toml: &Toml) -> &str {
+    match toml {
+        &Toml::Table(ref table) => {
+            match table.get("package") {
+                Some(&Toml::Table(ref table)) => {
+                    match table.get("name") {
+                        Some(&Toml::String(ref name)) => name,
+                        _ => panic!("failed to parse name"),
+                    }
+                }
+                _ => panic!("failed to parse package"),
+            }
+        }
+        _ => panic!("failed to parse Cargo.toml: incorrect format"),
+    }
+}
+
+fn parse_deps(toml: &Toml, top_pkg_name: &str) -> Result<Vec<String>, String> {
+    match cargo_lock_find_package(toml, top_pkg_name)? {
+        &Toml::Table(ref pkg) => {
+            if let Some(&Toml::Array(ref deps_toml_array)) = pkg.get("dependencies") {
+                deps_toml_array.iter()
+                    .map(|value| {
+                        if let Some(crate_name) = value.as_str() {
+                                crate_name_version(toml, crate_name)
+                        } else {
+                            Err("Empty dependency".to_string())
+                        }
+                    })
+                    .collect()
+            } else {
+                Err("error parsing dependencies table".to_string())
+            }
+        }
+        _ => Err("error parsing dependencies table".to_string()),
+    }
+}
+
+fn cargo_lock_find_package<'a>(toml: &'a Toml, pkg_name: &str) -> Result<&'a Toml, String> {
+    match toml.get("package") {
+        Some(&Toml::Array(ref pkgs)) => {
+            pkgs.iter()
+                .find(|pkg| {
+                    pkg.get("name")
+                    .map_or(false, |name| name.as_str().unwrap_or("") == pkg_name)
+                })
+                    .map_or(Err(format!("failed to find package {}", pkg_name)), |x| Ok(x))
+        }
+        _ => Err("failed to find packages in Cargo.lock".to_string()),
+    }
+}
+
+fn crate_name_version(toml: &Toml, crate_name: &str) -> Result<String, String> {
+    println!("Crate name: {}", crate_name.to_string());
+    if crate_name.contains(" ") {
+        let mut value_parts = crate_name.split(" ");
+        let crate_name = value_parts.next()
+            .map_or(Err(format!("failed to parse name from dependency string {:?}",    crate_name)), |x| Ok(x),
+        )?;
+        let crate_version = value_parts.next()
+            .map_or(Err(format!("failed to parse version from dependency string {:?}", crate_name)), |x| Ok(x),
+        )?;
+        
+        let value_pkg = cargo_lock_find_package(toml, crate_name)?;
+
+        let crate_source_str = value_pkg.get("source")            
+        .map_or("", |hash| hash.as_str().unwrap_or(""));
+        
+        //let crate_hash = crate_source_str.split("#").last().unwrap();
+        
+        println!("{}:{}:{}\n", crate_source_str, crate_name, crate_version);
+
+        Ok(format!("{}:{}:{}", crate_source_str, crate_name, crate_version))
+    } else {
+        let value_pkg = cargo_lock_find_package(toml, crate_name)?;
+        let crate_version = value_pkg.get("version")
+            .map_or(Err(format!("Version not found for {}",     crate_name)), |x| Ok(x),)?.as_str()
+            .map_or(Err(format!("Invalid version field for {}", crate_name)), |x| Ok(x))?;
+
+        let value_pkg = cargo_lock_find_package(toml, crate_name)?;
+
+        let crate_source_str = value_pkg.get("source")
+            .map_or("", |hash| hash.as_str().unwrap_or(""));
+
+        //let crate_hash = crate_source_str.split("#").last().unwrap();
+
+        println!("{}:{}:{}\n", crate_source_str, crate_name, crate_version);
+
+        Ok(format!("{}:{}:{}", crate_source_str, crate_name, crate_version))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,21 @@ fn print_build_info() -> String {
         TON NODE git commit:        {}\n\
         TON NODE git commit time:   {}\n\
         TON NODE git branch:        {}\n\
+<<<<<<< HEAD
+        ABI         git commit:     {}\n\
+        ADNL        git commit:     {}\n\
+        BLOCK       git commit:     {}\n\
+        BLOCK_JSON  git commit:     {}\n\
+        CRYPTO      git commit:     {}\n\
+        DHT         git commit:     {}\n\
+        EXECUTOR    git commit:     {}\n\
+        OVERLAY     git commit:     {}\n\
+        RLDP        git commit:     {}\n\
+        TL          git commit:     {}\n\
+        TYPES       git commit:     {}\n\
+        VM          git commit:     {}\n\
+        LOCKFREE    git commit:     {}\n",
+=======
         ABI git commit:             {}\n\
         ADNL git commit:            {}\n\
         BLOCK git commit:           {}\n\
@@ -292,6 +307,7 @@ fn print_build_info() -> String {
         TYPES git commit:           {}\n\
         VM git commit:              {}\n\
         LOCKFREE git commit:        {}\n",
+>>>>>>> 596c770126ba507cbe7e6287038a039f6bbeff60
 
         std::option_env!("BUILD_RUST_VERSION").unwrap_or("Not set"),
         std::option_env!("CARGO_PKG_VERSION").unwrap_or("Not set"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,36 +271,50 @@ fn log_version() {
 
 fn print_build_info() -> String {
     let build_info: String = format!(
-        "TON Node, version {}\n\
-        Rust: {}\n\
-        TON NODE git commit:         {}\n\
-        ADNL git commit:             {}\n\
-        DHT git commit:              {}\n\
-        OVERLAY git commit:          {}\n\
-        RLDP git commit:             {}\n\
-        TON_BLOCK git commit:        {}\n\
-        TON_BLOCK_JSON git commit:   {}\n\
-        TON_SDK git commit:          {}\n\
-        TON_EXECUTOR git commit:     {}\n\
-        TON_TL git commit:           {}\n\
-        TON_TYPES git commit:        {}\n\
-        TON_VM git commit:           {}\n\
-        TON_ABI git commit:     {}\n",
-        std::option_env!("CARGO_PKG_VERSION").unwrap_or("Not set"),
+       "Rust version:               {}\n\
+        TON NODE version:           {}\n\
+        TON NODE Block version:     {}\n\
+        TON NODE build time:        {}\n\
+        TON NODE build mode:        {}\n\
+        TON NODE git commit:        {}\n\
+        TON NODE git commit time:   {}\n\
+        TON NODE git branch:        {}\n\
+        ABI git commit:             {}\n\
+        ADNL git commit:            {}\n\
+        BLOCK git commit:           {}\n\
+        BLOCK_JSON git commit:      {}\n\
+        CRYPTO git commit:          {}\n\
+        DHT git commit:             {}\n\
+        EXECUTOR git commit:        {}\n\
+        OVERLAY git commit:         {}\n\
+        RLDP git commit:            {}\n\
+        TL git commit:              {}\n\
+        TYPES git commit:           {}\n\
+        VM git commit:              {}\n\
+        LOCKFREE git commit:        {}\n",
+
         std::option_env!("BUILD_RUST_VERSION").unwrap_or("Not set"),
-        std::option_env!("GC_TON_NODE").unwrap_or("Not set"),
+        std::option_env!("CARGO_PKG_VERSION").unwrap_or("Not set"),
+        ton_node::validating_utils::supported_version(),
+        std::option_env!("BUILD_TIME").unwrap_or("Not set"),
+        std::option_env!("BUILD_MODE").unwrap_or("Not set"),
+        std::option_env!("BUILD_GIT_COMMIT").unwrap_or("Not set"),
+        std::option_env!("BUILD_GIT_DATE").unwrap_or("Not set"),
+        std::option_env!("BUILD_GIT_BRANCH").unwrap_or("Not set"),
+
+        std::option_env!("GC_ABI").unwrap_or("Not set"),
         std::option_env!("GC_ADNL").unwrap_or("Not set"),
+        std::option_env!("GC_BLOCK").unwrap_or("Not set"),
+        std::option_env!("GC_BLOCK_JSON").unwrap_or("Not set"),
+        std::option_env!("GC_CRYPTO").unwrap_or("Not set"),
         std::option_env!("GC_DHT").unwrap_or("Not set"),
+        std::option_env!("GC_EXECUTOR").unwrap_or("Not set"),
         std::option_env!("GC_OVERLAY").unwrap_or("Not set"),
         std::option_env!("GC_RLDP").unwrap_or("Not set"),
-        std::option_env!("GC_TON_BLOCK").unwrap_or("Not set"),
-        std::option_env!("GC_TON_BLOCK_JSON").unwrap_or("Not set"),
-        std::option_env!("GC_TON_SDK").unwrap_or("Not set"),
-        std::option_env!("GC_TON_EXECUTOR").unwrap_or("Not set"),
-        std::option_env!("GC_TON_TL").unwrap_or("Not set"),
-        std::option_env!("GC_TON_TYPES").unwrap_or("Not set"),
-        std::option_env!("GC_TON_VM").unwrap_or("Not set"),
-        std::option_env!("GC_TON_LABS_ABI").unwrap_or("Not set")
+        std::option_env!("GC_TL").unwrap_or("Not set"),
+        std::option_env!("GC_TYPES").unwrap_or("Not set"),
+        std::option_env!("GC_VM").unwrap_or("Not set"),
+        std::option_env!("GC_LOCKFREE").unwrap_or("Not set"),
     );
     return build_info;
 }


### PR DESCRIPTION
This will add components commits hash and build info to the binary file.
Should look like

```
$ ./target/release/ton_node -V
Rust version:               rustc 1.65.0 (897e37553 2022-11-02)
TON NODE version:           0.51.14
TON NODE Block version:     33
TON NODE build time:        2022-12-07 14:15:28 +0200
TON NODE build mode:        RELEASE
TON NODE git commit:        b621e417bea9661cdc638a56106795d0f2994502
TON NODE git commit time:   2022-11-28 14:29:38 +0300
TON NODE git branch:        master
ABI git commit:             a021bcf0132167b6885152c83179eb108bb770d8:ton_abi:2.3.23
ADNL git commit:            45428e366e3bffc207bd4e96b52afe3fc4414585:adnl:0.7.92
BLOCK git commit:           063bcf6224e1e395c25a35c5cc165c331ec425c0:ton_block:1.8.16
BLOCK_JSON git commit:      40be8f54a3122193b71309f5a398c4308144616f:ton_block_json:0.7.55
CRYPTO git commit:          eff123bd8fb4857066b10da213169d2425bc4467:ever-crypto:0.1.55
DHT git commit:             2de55985f9731c21d9018995f2b5ca7acc950cd6:dht:0.5.90
EXECUTOR git commit:        768b8edf97eadab720279646dd966e7260cf2026:ton_executor:1.15.113
OVERLAY git commit:         23ba6c859103118a1675e240bdeb3c894d387e38:overlay:0.6.77
RLDP git commit:            f2431b7a39167e97dc728df66322100e8bcdbcc1:rldp:0.7.86
TL git commit:              8b09c4e78f54b419533b0b34cb03a635c81e3ea4:ton_api:0.2.143
TYPES git commit:           57bc54ff7cb66bbb32c684f7638848fa969c1eb7:ton_types:1.11.8
VM git commit:              f1ecdfa3c9821992a2000948138a79ef19aabc8c:ton_vm:1.8.58
LOCKFREE git commit:        bfcb66587dc4ffed9e8e9248995ad2fe8dc3669e:lockfree:0.5.1
```
